### PR TITLE
Add TypeScript type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,94 @@
+export interface RegulaOptions {
+  /** Input type: auto, tf, tf-plan, cfn, k8s, arm */
+  inputType?: "auto" | "tf" | "tf-plan" | "cfn" | "k8s" | "arm";
+  /** Additional rego rule files/directories to include */
+  include?: string | string[];
+  /** Only run these specific rule IDs */
+  only?: string | string[];
+  /** Exclude these specific rule IDs */
+  exclude?: string | string[];
+  /** Disable built-in rules (use only custom rules from include) */
+  noBuiltIns?: boolean;
+  /** Disable .gitignore filtering */
+  noIgnore?: boolean;
+  /** Terraform variable files (.tfvars) to use */
+  varFiles?: string | string[];
+}
+
+export interface SourceLocation {
+  path: string;
+  line: number;
+  column: number;
+}
+
+export interface RuleResult {
+  controls: string[];
+  families: string[];
+  filepath: string;
+  input_type: string;
+  provider: string;
+  resource_id: string;
+  resource_type: string;
+  resource_tags: Record<string, unknown>;
+  rule_description: string;
+  rule_id: string;
+  rule_message: string;
+  rule_name: string;
+  rule_raw_result: boolean;
+  rule_remediation_doc?: string;
+  rule_result: "PASS" | "FAIL" | "WAIVED";
+  rule_severity: "Unknown" | "Informational" | "Low" | "Medium" | "High" | "Critical";
+  rule_summary: string;
+  source_location?: SourceLocation[];
+  active_waivers?: string[];
+}
+
+export interface RegulaResult {
+  rule_results: RuleResult[];
+  summary: {
+    filepaths: string[];
+    rule_results: {
+      PASS: number;
+      FAIL: number;
+      WAIVED: number;
+    };
+    severities: {
+      Unknown: number;
+      Informational: number;
+      Low: number;
+      Medium: number;
+      High: number;
+      Critical: number;
+    };
+  };
+}
+
+/**
+ * Run regula on the specified path(s) and return parsed JSON results.
+ * @param paths - Path(s) to IaC files or directories
+ * @param options - Optional configuration
+ * @returns Parsed regula output with rule_results and summary
+ */
+export function runRegula(
+  paths: string | string[],
+  options?: RegulaOptions
+): Promise<RegulaResult>;
+
+/**
+ * Validate IaC files and return rule results.
+ * Alias for runRegula().
+ * @param paths - Path(s) to IaC files or directories
+ * @param options - Optional configuration
+ * @returns Object with rule_results and summary
+ */
+export function validate(
+  paths: string | string[],
+  options?: RegulaOptions
+): Promise<RegulaResult>;
+
+declare const _default: {
+  runRegula: typeof runRegula;
+  validate: typeof validate;
+};
+
+export default _default;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "regula-wasi",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Infrastructure as Code security and compliance evaluation tool (WASI build). Fork of fugue/regula with security patches.",
   "type": "module",
   "main": "index.js",
+  "types": "index.d.ts",
   "bin": {
     "regula": "cli.js"
   },
@@ -15,6 +16,7 @@
   },
   "files": [
     "index.js",
+    "index.d.ts",
     "cli.js",
     "regula.wasm",
     "README.md",


### PR DESCRIPTION
## Summary

- Add `index.d.ts` with full TypeScript type definitions
- Bump version to 3.2.4

## Types Added

- `RegulaOptions` - All configuration options
- `RegulaResult` - Full result structure with rule_results and summary
- `RuleResult` - Individual rule result with all fields
- `SourceLocation` - Source code location info

This fixes the TypeScript error:
```
Could not find a declaration file for module 'regula-wasi'
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TypeScript type definitions for complete type safety and enhanced IDE code completion.

* **Chores**
  * Version bump to 3.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->